### PR TITLE
Add content_country and app_language tags

### DIFF
--- a/newpipe_crash_report_importer/storage.py
+++ b/newpipe_crash_report_importer/storage.py
@@ -278,6 +278,8 @@ class SentryStorage(Storage):
                 "os": None,
                 "service": None,
                 "content_language": None,
+                "content_country": None,
+                "app_language": None,
             },
             "level": "error",
         }
@@ -293,7 +295,7 @@ class SentryStorage(Storage):
             except KeyError:
                 pass
 
-        for key in ["os", "service", "content_language"]:
+        for key in ["os", "service", "content_language", "content_country", "app_language"]:
             try:
                 rv["tags"][key] = newpipe_exc_info[key]
             except KeyError:


### PR DESCRIPTION
Introduced in NewPipe 0.19.6, see https://github.com/TeamNewPipe/NewPipe/pull/3579

@TheAssassin Do we need to enable the new tags in the Sentry config?